### PR TITLE
Fix categorical replacement

### DIFF
--- a/simpful/simpful.py
+++ b/simpful/simpful.py
@@ -349,14 +349,7 @@ class FuzzySystem(object):
         """
         if self._sanitize_input: name = self._sanitize(name)
         try: 
-            if isinstance(value,str):
-                self._templates_enabled = TEMPLATES_ENGAGED
-            elif isinstance(value,bool):
-                self._templates_enabled = TEMPLATES_ENGAGED
-            else: 
-                value = float(value)
-
-            self._variables[name] = value
+            self._variables[name] = float(value)
             if verbose: print(" * Variable %s set to %f" % (name, value))
         except ValueError:
             raise Exception("ERROR: specified value for "+name+" is not an integer or float: "+value)
@@ -519,7 +512,7 @@ class FuzzySystem(object):
         if self._sanitize_input: name = self._sanitize(name)
         self._outputfunctions[name]=function
         if "{" in function:
-            self._templates_enabled = True
+            self._templates_enabled = TEMPLATES_ENGAGED
             if verbose: 
                 print(" * Template system engaged")
 
@@ -576,7 +569,7 @@ class FuzzySystem(object):
                 exit()
 
             variable = substring[2: substring.find("IS")].strip()
-            case = substring[substring.find("IS")+2:substring.find("THEN")].strip()
+            case = float(substring[substring.find("IS")+2:substring.find("THEN")].strip())
             value = substring[substring.find("THEN")+4:].strip()
             if verbose: print(" * Analysing rule: IF %s IS %s THEN %s" % (variable, case, value))
 
@@ -656,11 +649,11 @@ class FuzzySystem(object):
                         
                         # replacement here
                         if self._check_templates() == TEMPLATES_ENGAGED:
-                            print(" * Replacing templates in function for '%s'" % res[0])
-                            print("   name of function: '%s'" % res[1])
                             string_to_evaluate = self._replace_values(string_to_evaluate, verbose=verbose)
-                            print(" * Final version of the '%s' rule: %s" % (res[1], string_to_evaluate))
-                        #exit()
+                            if verbose:
+                                print(" * Replacing templates in function for '%s'" % res[0])
+                                print("   name of function: '%s'" % res[1])
+                                print(" * Final version of the '%s' rule: %s" % (res[1], string_to_evaluate))
 
 
                         for k,v in self._variables.items():


### PR DESCRIPTION
This PR fixes two bug and reduces the logging:

1. It removes the possibility for `set_variable` to accept types non-convertible into floats, as not every part of the library supports string and boolean types. Specifically `Singleton_MF` only accepts float categories, and breaks if a string is provided.
2. It fixes a bug in the templates enabling (`self._templates_enabled = True` becomes `self._templates_enabled = TEMPLATES_ENGAGED`). Now, for the templates to be engaged, it is sufficient for a `{` character to be found in the output function. The process is no longer based on the type of the provided input variables.
3. The logs of the output function replacement will now be printed only if `verbose=True`.

I hope this can be merged soon, as it fixes important bugs for categories.
The PR can be modified if necessary.

Thx!