### PR TITLE
Fix axis mapping in plot_surface by updating meshgrid indexing (#30)

### DIFF
--- a/simpful/simpful.py
+++ b/simpful/simpful.py
@@ -1023,7 +1023,7 @@ class FuzzySystem(object):
             C.append(temp)
         C = array(C)
 
-        A,B = meshgrid(A,B)
+        A,B = meshgrid(A,B, indexing="ij")
 
         fig = figure(figsize=(8,6))
         ax = axes(projection='3d')


### PR DESCRIPTION
This PR addresses issue #30, which identified a bug in the `plot_surface` method of the `FuzzySystem` class. 

To fix the issue, the `meshgrid` call in `plot_surface` has been updated to use matrix indexing (`indexing="ij"`), which aligns with the way `C` is constructed. This ensures that the surface plot is generated correctly, with the axes properly reflecting the input variables.